### PR TITLE
feat: update workflow for direct publishing

### DIFF
--- a/.changeset/breezy-foxes-move.md
+++ b/.changeset/breezy-foxes-move.md
@@ -1,5 +1,0 @@
----
-"@1fe/sample-widget-base-config": minor
----
-
-add changesets

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -76,10 +76,11 @@ jobs:
       - name: Build package
         run: yarn build
 
-      - name: Create Release Pull Request or Publish to npm
+      - name: Publish to npm
         uses: changesets/action@v1
         with:
           publish: yarn changeset publish
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @1fe/sample-widget-base-config
+
+## 0.1.0
+
+### Minor Changes
+
+- f170e77: add changesets

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@1fe/sample-widget-base-config",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "publishConfig": {
     "access": "restricted",
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
- Update CI/CD workflow to publish directly without Version Packages PR
- Remove PR creation, keep direct npm publishing
- Add GitHub releases creation
- Version bump from 0.0.2 to 0.1.0
- Consume changeset: add changesets